### PR TITLE
Close file descriptor after use

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,7 @@ module.exports = {
 								if (newLineCharacters.includes(lines.substring(0, 1))) {
 									lines = lines.substring(1);
 								}
+								fsp.close(self.file);
 								return resolve(lines);
 							}
 
@@ -78,7 +79,12 @@ module.exports = {
 						do_while_loop();
 
 					});
-			}).catch(reject);
+			}).catch(function(reason) {
+				if (self.file !== null) {
+					fsp.close(self.file);
+				}
+				return reject(reason);
+			});
 		});
 	}
 };


### PR DESCRIPTION
The library seems to open the file but never close it. This leaves file descriptors open and prone to eventually hitting the OS's max number of open file descriptors.

This was noticed on a Windows 10 AWS server where the program would eventually get to the point where the call to open would never return because there were no free file descriptors for the OS to assign to the program. (I assume it's an OS limit, it could be a node limit though.) This bug was verified using ProcessExplorer to view the open handles for the file in question.