### PR TITLE
Run build on npm prepare instead of prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "babel src --presets babel-preset-es2015 --out-dir dist",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "test": "make test"
   },
   "repository": {


### PR DESCRIPTION
This is so that if the module is installed as a dependency via a git url instead of via npm, then in npm v5, it automatically installs devDependencies and runs the prepare hook (thus building the dist file).

(This unfortunately doesn't solve the issue of installing as a dependency via a tarball url, but at least it solves the issue of installing via a git url.)