### PR TITLE
Add encoding parameter, which defaults to 'utf8'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,13 @@ module.exports = {
 
 	/**
 	 * Read in the last `n` lines of a file
-	 * @param  {string}  file (direct or relative path to file.)
-	 * @param  {int}     maxLineCount max number of lines to read in.
-	 * @return {promise} new Promise, resolved with lines or rejected with error.
+	 * @param  {string}   file (direct or relative path to file.)
+	 * @param  {int}      maxLineCount max number of lines to read in.
+	 * @param  {encoding} specifies the character encoding to be used, or 'buffer'. defaults to 'utf8'.
+	 * @return {promise}  new Promise, resolved with lines or rejected with error.
 	 */
 
-	read: function(input_file_path, maxLineCount) {
+	read: function(input_file_path, maxLineCount, encoding) {
 		const readPreviousChar = function( stat, file, currentCharacterCount) {
 			return fsp.read(file, new Buffer(1), 0, 1, stat.size - 1 - currentCharacterCount)
 				.then((bytesReadAndBuffer) => {
@@ -63,7 +64,10 @@ module.exports = {
 									lines = lines.substring(1);
 								}
 								fsp.close(self.file);
-								return resolve(lines);
+								if (encoding === 'buffer') {
+									return resolve(Buffer.from(lines, 'binary'));
+								}
+								return resolve(Buffer.from(lines, 'binary').toString(encoding || 'utf8'));
 							}
 
 							readPreviousChar(self.stat, self.file, chars)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -57,6 +57,32 @@ describe("#equals", function() {
 			});
 	});
 
+	it("should return a buffer, when asked for", function() {
+		return rll.read("test/utf8", 2, 'buffer')
+			.then((lines) => {
+				expect(lines).to.be.an.instanceOf(Buffer);
+				expect(lines).to.have.lengthOf(163);
+			});
+	});
+
+	it("should return binary encoding, when asked for", function() {
+		return rll.read("test/utf8", 2, 'binary')
+			.then((lines) => {
+				expect(lines).to.be.a('string');
+				expect(lines).to.have.string("\xe4\xb8\xad");
+			});
+	});
+
+	it("should correctly read UTF-8 files", function() {
+		return rll.read("test/utf8", 2)
+			.then((lines) => {
+				expect(lines).to.be.a('string');
+				expect(lines).to.have.string("中文");
+				expect(lines).to.have.string("español");
+				expect(lines).to.have.string("português");
+				expect(lines).to.have.string("日本語");
+			});
+	});
 });
 
 let print_results = function(title, data) {

--- a/test/utf8
+++ b/test/utf8
@@ -1,0 +1,1 @@
+中文 español deutsch english हिन्दी العربية português বাংলা русский 日本語 ਪੰਜਾਬੀ 한국어 தமிழ்


### PR DESCRIPTION
The read loop should probably read into a buffer object and only convert to a string of the correct encoding at the end, but this works as a quick-ish fix.