### PR TITLE
Replaced new Buffer by Buffer.alloc due to deprecated warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ module.exports = {
 		}
 
 		const readPreviousChar = function( stat, file, currentCharacterCount) {
-			return fs.read(file, new Buffer(1), 0, 1, stat.size - 1 - currentCharacterCount)
+			return fs.read(file, Buffer.alloc(1), 0, 1, stat.size - 1 - currentCharacterCount)
 				.then((bytesReadAndBuffer) => {
 					return String.fromCharCode(bytesReadAndBuffer[1][0]);
 				});


### PR DESCRIPTION
Hello @alexbbt ,

This is the warning message:

```
(node:7727) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

You have a deprecated usage of `Buffer`. Instead doing `new Buffer()`, replace it by `Buffer.alloc()`. This pull request replaces `new Buffer(1)` by `Buffer.alloc(1)`. 

```
npm test
  #equals
    ✓ return all lines when asked for more than the file has
    ✓ return last line when asked for 1
    ✓ return last 2 lines when asked for 2
    ✓ return last 2 lines when asked for 2 and missing trailing new line
    ✓ Expect and error to be thrown if the file does not exist
    ✓ should the new line characters used by the file, when using non standard new line characters
    ✓ should return a buffer, when asked for
    ✓ should return binary encoding, when asked for
    ✓ should correctly read UTF-8 files
```

I hope it helps,
Jesús
