### PR TITLE
Specifying a bad encoding results in an `UnhandledPromiseRejectionWarning`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,0 @@
-test:
-	./node_modules/.bin/mocha --reporter spec
-
-.PHONY: test

--- a/package-lock.json
+++ b/package-lock.json
@@ -3609,9 +3609,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "babel src --out-dir dist",
     "build": "BABEL_ENV=production babel src --out-dir dist",
     "prepublishOnly": "npm run build",
-    "test": "make test",
+    "test": "./node_modules/.bin/mocha --reporter spec",
     "linting": "eslint src"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,10 @@ module.exports = {
 
 				}).catch((reason) => {
 					if (self.file !== null) {
-						fs.close(self.file);
+						fs.close(self.file).catch((error) => {
+							// We might get here if the encoding is invalid.
+							// Since we are already rejecting, let's ignore this error.
+						});
 					}
 					return reject(reason);
 				});

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -83,4 +83,8 @@ describe("#read", function() {
 				expect(lines).to.have.string("日本語");
 			});
 	});
+
+	it("should error if the encoding is invalid", function() {
+		return assert.isRejected(rll.read("test/numbered", 2, "bad-encoding"), "Unknown encoding: bad-encoding");
+	});
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,7 +10,7 @@ const expect = chai.expect;
 const assert = chai.assert;
 
 
-describe("#equals", function() {
+describe("#read", function() {
 	it("return all lines when asked for more than the file has", function() {
 		return rll.read("test/numbered", 15)
 			.then((lines) => {


### PR DESCRIPTION
For example, calling `rll.read("test/numbered", 2, "bad-encoding")` outputs the following:
```
(node:338) UnhandledPromiseRejectionWarning: Error: EBADF: bad file descriptor, close
(node:338) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:338) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

**Platform Info**
```
$ npm --versions
{ 'read-last-lines': '1.7.0',
  npm: '6.9.0',
  ares: '1.15.0',
  cldr: '33.1',
  http_parser: '2.8.0',
  icu: '62.1',
  modules: '64',
  napi: '3',
  nghttp2: '1.34.0',
  node: '10.15.3',
  openssl: '1.1.0j',
  tz: '2018e',
  unicode: '11.0',
  uv: '1.23.2',
  v8: '6.8.275.32-node.51',
  zlib: '1.2.11' }
$ node -p process.platform
linux
```