### PR TITLE
fix: do not under-read newline-only files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,12 @@ module.exports = {
 
 						if (lines.length >= self.stat.size || lineCount >= maxLineCount) {
 							if (NEW_LINE_CHARACTERS.includes(lines.substring(0, 1))) {
-								lines = lines.substring(1);
+								const trimmed = lines.substring(1);
+								const maxLines = Math.ceil(Number(maxLineCount));
+								// Keep a leading newline when trimming would under-read (e.g. newline-only files).
+								if (logicalLineCount(trimmed) >= maxLines || logicalLineCount(lines) > maxLines) {
+									lines = trimmed;
+								}
 							}
 							// Cap over-reads from multiple trailing newlines (#41).
 							while (logicalLineCount(lines) > Math.ceil(Number(maxLineCount))) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -142,9 +142,8 @@ describe("#read", function() {
 
 		try {
 			const lines = await rll.read(tempFile, 3);
-			expect(lines).to.match(/^\n*$/);
-			expect(countLogicalLines(lines)).to.be.at.most(3);
-			expect(lines).to.equal("\n\n");
+			expect(lines).to.equal("\n\n\n");
+			expect(countLogicalLines(lines)).to.equal(3);
 		} finally {
 			await fsp.unlink(tempFile);
 			await fsp.rmdir(tempDir);


### PR DESCRIPTION
## Summary
Asking for 3 lines from a `\n\n\n` file previously returned `\n\n` (2 logical lines) because the leading-newline trim discarded content.

Only trim a leading `\n` when the result still meets `maxLineCount` (or we are over and the #41 cap will trim). Newline-only files now return `\n\n\n` when asked for 3.

Small, separate from the upcoming chunked rewrite so the behavior change is explicit.

## Test plan
- [x] `npm test` (20 passing)
- [x] Existing #41 / exact-count / trailing-newline cases still pass


Made with [Cursor](https://cursor.com)