### PR TITLE
perf: chunked reverse reads

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,45 @@
 const fs = require("fs/promises");
 
+const DEFAULT_CHUNK_SIZE = 64 * 1024;
+
+function logicalLineCount(data) {
+	if (!data) {
+		return 0;
+	}
+	let normalized = data.replace(/\r\n/g, "\n");
+	if (normalized.endsWith("\n")) {
+		normalized = normalized.slice(0, -1);
+	}
+	return normalized ? normalized.split("\n").length : 0;
+}
+
+function finalizeLines(lines, maxLineCount) {
+	if (lines.startsWith("\n")) {
+		const trimmed = lines.substring(1);
+		const maxLines = Math.ceil(Number(maxLineCount));
+		// Keep a leading newline when trimming would under-read (e.g. newline-only files).
+		if (logicalLineCount(trimmed) >= maxLines || logicalLineCount(lines) > maxLines) {
+			lines = trimmed;
+		}
+	}
+	// Cap over-reads from multiple trailing newlines (#41).
+	while (logicalLineCount(lines) > Math.ceil(Number(maxLineCount))) {
+		const nextNewline = lines.indexOf("\n");
+		if (nextNewline === -1) {
+			return "";
+		}
+		lines = lines.substring(nextNewline + 1);
+	}
+	return lines;
+}
+
+function decodeResult(lines, encoding) {
+	if (encoding === "buffer") {
+		return Buffer.from(lines, "binary");
+	}
+	return Buffer.from(lines, "binary").toString(encoding);
+}
+
 module.exports = {
 	/**
 	 * Read in the last `n` lines of a file
@@ -10,122 +50,89 @@ module.exports = {
 	 * @return {promise}  a promise resolved with the lines or rejected with an error.
 	 */
 	read: function(input_file_path, maxLineCount, encoding) {
-
-		const NEW_LINE_CHARACTERS = ["\n"];
-
 		if (encoding == null) {
 			encoding = "utf8";
 		}
 
-		const readPreviousChar = function(stat, file, currentCharacterCount) {
-			return file.read(Buffer.alloc(1), 0, 1, stat.size - 1 - currentCharacterCount)
-				.then(({ buffer }) => {
-					return String.fromCharCode(buffer[0]);
-				});
-		};
-
-		const logicalLineCount = function(data) {
-			if (!data) {
-				return 0;
-			}
-			let normalized = data.replace(/\r\n/g, "\n");
-			if (normalized.endsWith("\n")) {
-				normalized = normalized.slice(0, -1);
-			}
-			return normalized ? normalized.split("\n").length : 0;
-		};
-
-		return new Promise((resolve, reject) => {
-			let self = {
-				stat: null,
-				file: null,
-			};
-
-			fs.access(input_file_path)
-				.catch((err) => {
+		return (async() => {
+			let file = null;
+			try {
+				try {
+					file = await fs.open(input_file_path, "r");
+				} catch (err) {
 					if (err && err.code === "ENOENT") {
 						throw new Error("file does not exist");
 					}
 					throw err;
-				})
-				.then(() => {
-					let promises = [];
+				}
 
-					// Load file Stats.
-					promises.push(
-						fs.stat(input_file_path)
-							.then(stat => self.stat = stat));
+				const stat = await file.stat();
 
-					// Open file for reading.
-					promises.push(
-						fs.open(input_file_path, "r")
-							.then(file => self.file = file));
+				if (maxLineCount <= 0) {
+					return encoding === "buffer" ? Buffer.alloc(0) : "";
+				}
 
-					return Promise.all(promises);
-				}).then(() => {
-					if (maxLineCount <= 0) {
-						self.file.close();
-						if (encoding === "buffer") {
-							return resolve(Buffer.alloc(0));
+				if (stat.size === 0) {
+					return encoding === "buffer" ? Buffer.alloc(0) : "";
+				}
+
+				// Match prior coercion: NaN / Infinity never satisfy lineCount >= max, so read all.
+				const readAll = !Number.isFinite(Number(maxLineCount));
+				const chunks = [];
+				let position = stat.size;
+				let lineCount = 0;
+				let skippedTrailingNewline = false;
+
+				while (position > 0 && (readAll || !(lineCount >= maxLineCount))) {
+					const bytesToRead = Math.min(DEFAULT_CHUNK_SIZE, position);
+					position -= bytesToRead;
+
+					const chunk = Buffer.allocUnsafe(bytesToRead);
+					const { bytesRead } = await file.read(chunk, 0, bytesToRead, position);
+					const buf = bytesRead === bytesToRead ? chunk : chunk.subarray(0, bytesRead);
+
+					let sliceFrom = 0;
+					let hitBoundary = false;
+
+					for (let i = buf.length - 1; i >= 0; i--) {
+						if (buf[i] !== 0x0a) {
+							continue;
 						}
-						return resolve("");
+
+						// Same idea as before: the file's final newline is not a line by itself.
+						if (!skippedTrailingNewline && position + buf.length === stat.size && i === buf.length - 1) {
+							skippedTrailingNewline = true;
+							continue;
+						}
+
+						lineCount++;
+						if (!readAll && lineCount >= maxLineCount) {
+							// Keep content after this newline (the last maxLineCount lines).
+							sliceFrom = i + 1;
+							hitBoundary = true;
+							break;
+						}
 					}
 
-					let chars = 0;
-					let lineCount = 0;
-					let lines = "";
-
-					const do_while_loop = function() {
-						if (lines.length > self.stat.size) {
-							lines = lines.substring(lines.length - self.stat.size);
+					if (hitBoundary) {
+						if (sliceFrom < buf.length) {
+							chunks.push(buf.subarray(sliceFrom));
 						}
-
-						if (lines.length >= self.stat.size || lineCount >= maxLineCount) {
-							if (NEW_LINE_CHARACTERS.includes(lines.substring(0, 1))) {
-								const trimmed = lines.substring(1);
-								const maxLines = Math.ceil(Number(maxLineCount));
-								// Keep a leading newline when trimming would under-read (e.g. newline-only files).
-								if (logicalLineCount(trimmed) >= maxLines || logicalLineCount(lines) > maxLines) {
-									lines = trimmed;
-								}
-							}
-							// Cap over-reads from multiple trailing newlines (#41).
-							while (logicalLineCount(lines) > Math.ceil(Number(maxLineCount))) {
-								const nextNewline = lines.indexOf("\n");
-								if (nextNewline === -1) {
-									lines = "";
-									break;
-								}
-								lines = lines.substring(nextNewline + 1);
-							}
-							self.file.close();
-							if (encoding === "buffer") {
-								return resolve(Buffer.from(lines, "binary"));
-							}
-							return resolve(Buffer.from(lines, "binary").toString(encoding));
-						}
-
-						return readPreviousChar(self.stat, self.file, chars)
-							.then((nextCharacter) => {
-								lines = nextCharacter + lines;
-								if (NEW_LINE_CHARACTERS.includes(nextCharacter) && lines.length > 1) {
-									lineCount++;
-								}
-								chars++;
-							})
-							.then(do_while_loop);
-					};
-					return do_while_loop();
-
-				}).catch((reason) => {
-					if (self.file !== null) {
-						self.file.close().catch(() => {
-							// We might get here if the encoding is invalid.
-							// Since we are already rejecting, let's ignore this error.
-						});
+						break;
 					}
-					return reject(reason);
-				});
-		});
+
+					chunks.push(buf);
+				}
+
+				const lines = finalizeLines(Buffer.concat(chunks.reverse()).toString("binary"), maxLineCount);
+				return decodeResult(lines, encoding);
+			} finally {
+				if (file) {
+					await file.close().catch(() => {
+						// Ignore close errors when already rejecting for another reason.
+					});
+				}
+			}
+		})();
 	},
 };

--- a/src/index.js
+++ b/src/index.js
@@ -17,12 +17,10 @@ function finalizeLines(lines, maxLineCount) {
 	if (lines.startsWith("\n")) {
 		const trimmed = lines.substring(1);
 		const maxLines = Math.ceil(Number(maxLineCount));
-		// Keep a leading newline when trimming would under-read (e.g. newline-only files).
 		if (logicalLineCount(trimmed) >= maxLines || logicalLineCount(lines) > maxLines) {
 			lines = trimmed;
 		}
 	}
-	// Cap over-reads from multiple trailing newlines (#41).
 	while (logicalLineCount(lines) > Math.ceil(Number(maxLineCount))) {
 		const nextNewline = lines.indexOf("\n");
 		if (nextNewline === -1) {
@@ -31,13 +29,6 @@ function finalizeLines(lines, maxLineCount) {
 		lines = lines.substring(nextNewline + 1);
 	}
 	return lines;
-}
-
-function decodeResult(lines, encoding) {
-	if (encoding === "buffer") {
-		return Buffer.from(lines, "binary");
-	}
-	return Buffer.from(lines, "binary").toString(encoding);
 }
 
 module.exports = {
@@ -49,90 +40,90 @@ module.exports = {
 	 *
 	 * @return {promise}  a promise resolved with the lines or rejected with an error.
 	 */
-	read: function(input_file_path, maxLineCount, encoding) {
+	read: async function(input_file_path, maxLineCount, encoding) {
 		if (encoding == null) {
 			encoding = "utf8";
 		}
 
-		return (async() => {
-			let file = null;
+		let file = null;
+		try {
 			try {
-				try {
-					file = await fs.open(input_file_path, "r");
-				} catch (err) {
-					if (err && err.code === "ENOENT") {
-						throw new Error("file does not exist");
-					}
-					throw err;
+				file = await fs.open(input_file_path, "r");
+			} catch (err) {
+				if (err && err.code === "ENOENT") {
+					throw new Error("file does not exist");
 				}
+				throw err;
+			}
 
-				const stat = await file.stat();
+			const stat = await file.stat();
 
-				if (maxLineCount <= 0) {
-					return encoding === "buffer" ? Buffer.alloc(0) : "";
-				}
+			if (maxLineCount <= 0) {
+				return encoding === "buffer" ? Buffer.alloc(0) : "";
+			}
 
-				if (stat.size === 0) {
-					return encoding === "buffer" ? Buffer.alloc(0) : "";
-				}
+			if (stat.size === 0) {
+				return encoding === "buffer" ? Buffer.alloc(0) : "";
+			}
 
-				// Match prior coercion: NaN / Infinity never satisfy lineCount >= max, so read all.
-				const readAll = !Number.isFinite(Number(maxLineCount));
-				const chunks = [];
-				let position = stat.size;
-				let lineCount = 0;
-				let skippedTrailingNewline = false;
+			// NaN / Infinity never satisfy lineCount >= max, so read the whole file.
+			const readAll = !Number.isFinite(Number(maxLineCount));
+			const chunks = [];
+			let position = stat.size;
+			let lineCount = 0;
+			let skippedTrailingNewline = false;
 
-				while (position > 0 && (readAll || !(lineCount >= maxLineCount))) {
-					const bytesToRead = Math.min(DEFAULT_CHUNK_SIZE, position);
-					position -= bytesToRead;
+			while (position > 0 && (readAll || !(lineCount >= maxLineCount))) {
+				const bytesToRead = Math.min(DEFAULT_CHUNK_SIZE, position);
+				position -= bytesToRead;
 
-					const chunk = Buffer.allocUnsafe(bytesToRead);
-					const { bytesRead } = await file.read(chunk, 0, bytesToRead, position);
-					const buf = bytesRead === bytesToRead ? chunk : chunk.subarray(0, bytesRead);
+				const chunk = Buffer.allocUnsafe(bytesToRead);
+				const { bytesRead } = await file.read(chunk, 0, bytesToRead, position);
+				const buf = bytesRead === bytesToRead ? chunk : chunk.subarray(0, bytesRead);
 
-					let sliceFrom = 0;
-					let hitBoundary = false;
+				let sliceFrom = 0;
+				let hitBoundary = false;
 
-					for (let i = buf.length - 1; i >= 0; i--) {
-						if (buf[i] !== 0x0a) {
-							continue;
-						}
-
-						// Same idea as before: the file's final newline is not a line by itself.
-						if (!skippedTrailingNewline && position + buf.length === stat.size && i === buf.length - 1) {
-							skippedTrailingNewline = true;
-							continue;
-						}
-
-						lineCount++;
-						if (!readAll && lineCount >= maxLineCount) {
-							// Keep content after this newline (the last maxLineCount lines).
-							sliceFrom = i + 1;
-							hitBoundary = true;
-							break;
-						}
+				for (let i = buf.length - 1; i >= 0; i--) {
+					if (buf[i] !== 0x0a) {
+						continue;
 					}
 
-					if (hitBoundary) {
-						if (sliceFrom < buf.length) {
-							chunks.push(buf.subarray(sliceFrom));
-						}
+					// Skip the file's final trailing newline once.
+					if (!skippedTrailingNewline && position + buf.length === stat.size && i === buf.length - 1) {
+						skippedTrailingNewline = true;
+						continue;
+					}
+
+					lineCount++;
+					if (!readAll && lineCount >= maxLineCount) {
+						sliceFrom = i + 1;
+						hitBoundary = true;
 						break;
 					}
-
-					chunks.push(buf);
 				}
 
-				const lines = finalizeLines(Buffer.concat(chunks.reverse()).toString("binary"), maxLineCount);
-				return decodeResult(lines, encoding);
-			} finally {
-				if (file) {
-					await file.close().catch(() => {
-						// Ignore close errors when already rejecting for another reason.
-					});
+				if (hitBoundary) {
+					if (sliceFrom < buf.length) {
+						chunks.push(buf.subarray(sliceFrom));
+					}
+					break;
 				}
+
+				chunks.push(buf);
 			}
-		})();
+
+			const lines = finalizeLines(Buffer.concat(chunks.reverse()).toString("binary"), maxLineCount);
+			if (encoding === "buffer") {
+				return Buffer.from(lines, "binary");
+			}
+			return Buffer.from(lines, "binary").toString(encoding);
+		} finally {
+			if (file) {
+				await file.close().catch(() => {
+					// Ignore close errors when already rejecting for another reason.
+				});
+			}
+		}
 	},
 };


### PR DESCRIPTION
## Summary
Replaces byte-at-a-time reverse reads with 64KiB chunked reads (#26).

Behavior is unchanged for the public API:
- Same `read(path, n, encoding)` shape, including `"buffer"`
- Same `maxLineCount` coercion (`"2"`, `1.5`, `NaN`, `Infinity`)
- Same `#41` cap and newline-only handling
- Same `"file does not exist"` error

Verified against the previous bytewise implementation on extra fixtures (including a line that spans the chunk boundary).

## Test plan
- [x] `npm test` (20 passing)
- [x] `npm run linting`
- [x] Parity check vs previous bytewise implementation
- [ ] Optional: quick `npm run analyze` smoke after merge